### PR TITLE
Add include company filter && Fix filter doesn't apply well

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ filters:
   min_transaction_value: 0     # Minimaler Transaktionswert in USD
   transaction_types: []        # Leer = alle Typen, oder Liste: ["P", "S", "A", etc.]
   exclude_companies: []        # Liste von Ticker-Symbolen die ausgeschlossen werden sollen
-  include_companies: ["AAPL"]        # Liste von Ticker-Symbolen die ausgeschlossen werden sollen
+  include_companies: []        # Liste von Ticker-Symbolen die ausgeschlossen werden sollen
   min_shares_traded: 0        # Minimale Anzahl gehandelter Aktien
 
 # Logging-Einstellungen

--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,7 @@ filters:
   min_transaction_value: 0     # Minimaler Transaktionswert in USD
   transaction_types: []        # Leer = alle Typen, oder Liste: ["P", "S", "A", etc.]
   exclude_companies: []        # Liste von Ticker-Symbolen die ausgeschlossen werden sollen
+  include_companies: ["AAPL"]        # Liste von Ticker-Symbolen die ausgeschlossen werden sollen
   min_shares_traded: 0        # Minimale Anzahl gehandelter Aktien
 
 # Logging-Einstellungen


### PR DESCRIPTION
HI, Germany

I want to add a feature that filter companies that i want to check. So I make it and add it your code.

AND I FOUND CRITICAL PARSING ERROR THAT INTERUPT FILTERING.

the cause of this error is real data from site is like that

 `D,2025-01-02 13:05:12,2025-01-02 13:05:12,SPG,SPG,Simon Property Group Inc /de/,Selig Stefan M,P - Purchase,$168.59,+187,"30,260",+1%,"+$31,526"`

but your code parse this data just 
`field_names = ['transaction_date', 'trade_date', 'ticker', 'company_name', 
                      'owner_name', 'Title', 'transaction_type', 'last_price', 
                      'Qty', 'shares_held', 'Owned', 'Value']`
so The order is pushed back one space at a time. 
Now I change that code. please check it.